### PR TITLE
Adding IE support

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
 class ApplicationController < ActionController::Base
 
+  before_filter { response.headers['P3P'] = %q|CP="HONK"| }
+
 end

--- a/public/javascripts/chat.js
+++ b/public/javascripts/chat.js
@@ -8,14 +8,16 @@ $(document).ready(function()
 	var audio = document.createElement("audio");
 	var audio_types = ["ogg", "mpeg", "wav"];
 	// Loop through the types I have and break out when the browser says it might be able to play one
-	for(type in audio_types) {
-		var type_name = audio_types[type];
-		if(audio.canPlayType("audio/" + type_name) == "yes" || audio.canPlayType("audio/" + type_name) == "maybe") {
-			browser_audio_type = type_name;
-			break;
-		}
+	if (typeof audio.canPlayType == 'function') {
+  	for(type in audio_types) {
+  		var type_name = audio_types[type];
+  		if(audio.canPlayType("audio/" + type_name) == "yes" || audio.canPlayType("audio/" + type_name) == "maybe") {
+  			browser_audio_type = type_name;
+  			break;
+  		}
+  	}
 	}
-	
+
 	// Logging - Disable in production
 	// Pusher.log = function() { if (window.console) window.console.log.apply(window.console, arguments); };
 	


### PR DESCRIPTION
Fixing both:
1. no audio support in IE would break pusherchat and
2. IE doesn't accept cookies by default when using pusherchat inside an iframe. 
